### PR TITLE
Fix location of elm-package.json

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -43,7 +43,7 @@ class ElmMakeLint(Linter):
     def run(self, cmd, code):
         """Run elm-make, transform json into a string parseable by the regex."""
 
-        root_dir = find_file_up('elm-package.json', os.path.abspath('.'))
+        root_dir = find_file_up('elm-package.json', os.path.abspath(self.view.file_name()))
         if root_dir:
             os.chdir(root_dir)
         else:


### PR DESCRIPTION
I had an issue with this plugin finding my `elm-package.json`. I have a repo structure that looks like this:

```
root (this is where .git is)
- frontend
  - elm-package.json
  - src
    - elm files go here...
- backend
  - an Elixir app
```

And I ran Sublime with `subl frontend` so it loads up that folder. However, whenever I edited `src/Main.elm`, it would fail to find `elm-package.json`.

From some debugging, I realised that `os.path.abspath('.')` gave me the root folder, not `frontend`, and so it was skipping out the directory that had the `elm-package.json`. I'm not sure why.

I managed to fix it from starting with the current path of the file being edited; but I'm open to a better solution or it being explained why this wasn't working for me locally.

